### PR TITLE
Camera now locks to the player instead of the world

### DIFF
--- a/Roche-Engine/Objects/Camera.cpp
+++ b/Roche-Engine/Objects/Camera.cpp
@@ -81,13 +81,13 @@ void Camera::HandleEvent( Event* event )
 	{
 		if ( m_bLockedToPlayer )
 		{
-			std::pair<Sprite*, Vector2f*>* charSpriteandPos = static_cast<std::pair<Sprite*, Vector2f*>*>( event->GetData() );
-			m_vPosition = XMFLOAT2( charSpriteandPos->second->x, charSpriteandPos->second->y );
+			std::pair<Sprite*, Vector2f*>* charSpriteandPos = static_cast<std::pair<Sprite*, Vector2f*>*>(event->GetData());
 			Sprite* charSprite = charSpriteandPos->first;
+			m_vPosition = XMFLOAT2(charSpriteandPos->second->x + charSprite->GetWidth(), charSpriteandPos->second->y + charSprite->GetHeight());
 
 			m_mWorldMatrix = XMMatrixTranslation(
-				-( m_vPosition.x - m_vSizeOfScreen.x / 2.0f + charSprite->GetWidth() ),
-				-( m_vPosition.y - m_vSizeOfScreen.y / 2.0f + charSprite->GetHeight() ), 0.0f );
+				-(m_vPosition.x - m_vSizeOfScreen.x / 2.0f),
+				-(m_vPosition.y - m_vSizeOfScreen.y / 2.0f), 0.0f);
 		}
 	}
 	break;


### PR DESCRIPTION
**Describe your changes**
Fixes display bug with culling due to the camera not locking fully onto the player and then the world doing it some

**Screenshots**
If applicable, add screenshots to help explain your changes.

**Additional context**
Add any other context about your changes here.
