### PR TITLE
Updated Camera to work with different level TileMaps

### DIFF
--- a/Roche-Engine/Objects/Camera.cpp
+++ b/Roche-Engine/Objects/Camera.cpp
@@ -13,12 +13,7 @@ void Camera::SetProjectionValues( float width, float height, float nearZ, float 
 	m_vPosition = { m_vSizeOfScreen.x / 2.0f, m_vSizeOfScreen.y / 2.0f };
 	m_mOrthoMatrix = XMMatrixOrthographicOffCenterLH( 0.0f, width, height, 0.0f, nearZ, farZ );
 
-	static bool firstTime = true;
-	if (firstTime)
-	{
-		m_vInitPosition = m_vPosition;
-		firstTime = false;
-	}
+	m_vInitPosition = m_vPosition;
 }
 
 void Camera::SpawnControlWindow()

--- a/Roche-Engine/Resources/Levels.json
+++ b/Roche-Engine/Resources/Levels.json
@@ -3,24 +3,24 @@
 		"name": "Menu",
 		"audio": "!SoundBankList.json",
 		"entity": "Entity.json",
-		"tmBack": "newfile2.json",
-		"tmFront": "newfile2.json",
+		"tmBack": "67x120file.json",
+		"tmFront": "67x120file.json",
 		"ui": "Menu.json"
 	},
 	{
 		"name": "Game",
 		"audio": "!SoundBankList.json",
 		"entity": "Entity.json",
-		"tmBack": "newfile2.json",
-		"tmFront": "newfile2.json",
+		"tmBack": "67x120file.json",
+		"tmFront": "67x120file.json",
 		"ui": "Game.json"
 	},
 	{
 		"name": "Credits",
 		"audio": "!SoundBankList.json",
 		"entity": "Entity.json",
-		"tmBack": "newfile2.json",
-		"tmFront": "newfile2.json",
+		"tmBack": "67x120file.json",
+		"tmFront": "67x120file.json",
 		"ui": "Credits.json"
 	}
 ]


### PR DESCRIPTION
**Describe your changes**
Removed a static, to allow the camera init pos to be set on every lvl.
Lvl switching now works and shows the respective tilemaps

**Screenshots**
If applicable, add screenshots to help explain your changes.

**Additional context**
Add any other context about your changes here.
